### PR TITLE
Disable WebGL debug mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
 		<meta charset="utf-8">
 		<link rel="icon" type="image/png" href="icon.png">
 		
-			<script src="webgl-debug.js"></script>
+			<!--<script src="webgl-debug.js"></script>-->
 		
 		
 			<script>


### PR DESCRIPTION
When debug mode is enabled ~50ms of latency is added for every GL call.

This patch should make the UI feel very responsible like a normal web app.