### PR TITLE
Add script to generate and remove GopherJS leftover

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Fyne WASM Demo
+
+This repository contains the code for the [demo.fyne.io](https://demo.fyne.io) site running Fyne using WebAssembly.

--- a/index.html
+++ b/index.html
@@ -38,8 +38,6 @@
 		<meta charset="utf-8">
 		<link rel="icon" type="image/png" href="icon.png">
 		
-			<!--<script src="webgl-debug.js"></script>-->
-		
 			<script>
 				function getChromeVersion() {
 					var raw = navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./);

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# Usage:
+# Pass the Fyne version in as argument to regenerate with that version.
+# Example: ./update.sh v2.5.3
+
+# Exit on error:
+set -e
+
+# File path variables:
+URL="https://github.com/fyne-io/fyne/archive/refs/tags/$1.tar.gz"
+TEMP_DIR=$(mktemp -d)
+OUT_FILE="$TEMP_DIR/$1.tar.gz"
+DEMO_PATH="$TEMP_DIR/cmd/fyne_demo"
+
+# Download, extract, package and copy here before cleanup:
+wget -O $OUT_FILE $URL
+echo $OUT_FILE
+tar -xzf $OUT_FILE -C $TEMP_DIR --strip-components=1
+(cd $DEMO_PATH && ~/go/bin/fyne package --release --os=wasm)
+cp -rvf $DEMO_PATH/wasm/* .
+rm -rf $TEMP_DIR

--- a/wasm_exec.js
+++ b/wasm_exec.js
@@ -113,6 +113,10 @@
 				this.mem.setUint32(addr + 4, Math.floor(v / 4294967296), true);
 			}
 
+			const setInt32 = (addr, v) => {
+				this.mem.setUint32(addr + 0, v, true);
+			}
+
 			const getInt64 = (addr) => {
 				const low = this.mem.getUint32(addr + 0, true);
 				const high = this.mem.getInt32(addr + 4, true);
@@ -206,7 +210,10 @@
 
 			const timeOrigin = Date.now() - performance.now();
 			this.importObject = {
-				go: {
+				_gotest: {
+					add: (a, b) => a + b,
+				},
+				gojs: {
 					// Go's SP does not change as long as no Go code is running. Some operations (e.g. calls, getters and setters)
 					// may synchronously trigger a Go event handler. This makes Go code get executed in the middle of the imported
 					// function. A goroutine can switch to a new stack if the current stack is too small (see morestack function).
@@ -269,7 +276,7 @@
 									this._resume();
 								}
 							},
-							getInt64(sp + 8) + 1, // setTimeout has been seen to fire up to 1 millisecond early
+							getInt64(sp + 8),
 						));
 						this.mem.setInt32(sp + 16, id, true);
 					},


### PR DESCRIPTION
I implemented a script to automate this and performed a rebuild using Go 1.23.4 (latest version of Go).

Fixes #2, #3 