### PR TITLE
Update script to generate new demo

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -19,3 +19,4 @@ tar -xzf $OUT_FILE -C $TEMP_DIR --strip-components=1
 (cd $TEMP_DIR && ~/go/bin/fyne package -release -os=wasm)
 cp -rvf $TEMP_DIR/wasm/* .
 rm -rf $TEMP_DIR
+wasm-opt "Fyne Demo.wasm" --enable-bulk-memory-opt -O2 -o "Fyne Demo.wasm"

--- a/update.sh
+++ b/update.sh
@@ -1,22 +1,21 @@
 #!/bin/sh
 
 # Usage:
-# Pass the Fyne version in as argument to regenerate with that version.
-# Example: ./update.sh v2.5.3
+# Pass the demo version in as argument to regenerate with that version.
+# Example: ./update.sh v1.6.0
 
 # Exit on error:
 set -e
 
 # File path variables:
-URL="https://github.com/fyne-io/fyne/archive/refs/tags/$1.tar.gz"
+URL="https://github.com/fyne-io/demo/archive/refs/tags/$1.tar.gz"
 TEMP_DIR=$(mktemp -d)
 OUT_FILE="$TEMP_DIR/$1.tar.gz"
-DEMO_PATH="$TEMP_DIR/cmd/fyne_demo"
 
 # Download, extract, package and copy here before cleanup:
 wget -O $OUT_FILE $URL
 echo $OUT_FILE
 tar -xzf $OUT_FILE -C $TEMP_DIR --strip-components=1
-(cd $DEMO_PATH && ~/go/bin/fyne package --release --os=wasm)
-cp -rvf $DEMO_PATH/wasm/* .
+(cd $TEMP_DIR && ~/go/bin/fyne package -release -os=wasm)
+cp -rvf $TEMP_DIR/wasm/* .
 rm -rf $TEMP_DIR

--- a/wasm_exec.js
+++ b/wasm_exec.js
@@ -14,7 +14,7 @@
 	if (!globalThis.fs) {
 		let outputBuf = "";
 		globalThis.fs = {
-			constants: { O_WRONLY: -1, O_RDWR: -1, O_CREAT: -1, O_TRUNC: -1, O_APPEND: -1, O_EXCL: -1 }, // unused
+			constants: { O_WRONLY: -1, O_RDWR: -1, O_CREAT: -1, O_TRUNC: -1, O_APPEND: -1, O_EXCL: -1, O_DIRECTORY: -1 }, // unused
 			writeSync(fd, buf) {
 				outputBuf += decoder.decode(buf);
 				const nl = outputBuf.lastIndexOf("\n");
@@ -70,6 +70,14 @@
 			umask() { throw enosys(); },
 			cwd() { throw enosys(); },
 			chdir() { throw enosys(); },
+		}
+	}
+
+	if (!globalThis.path) {
+		globalThis.path = {
+			resolve(...pathSegments) {
+				return pathSegments.join("/");
+			}
 		}
 	}
 
@@ -208,10 +216,16 @@
 				return decoder.decode(new DataView(this._inst.exports.mem.buffer, saddr, len));
 			}
 
+			const testCallExport = (a, b) => {
+				this._inst.exports.testExport0();
+				return this._inst.exports.testExport(a, b);
+			}
+
 			const timeOrigin = Date.now() - performance.now();
 			this.importObject = {
 				_gotest: {
 					add: (a, b) => a + b,
+					callExport: testCallExport,
 				},
 				gojs: {
 					// Go's SP does not change as long as no Go code is running. Some operations (e.g. calls, getters and setters)


### PR DESCRIPTION
This updates the script to use the new demo, regenerates with Go 1.24.3 (brings a new `wasm_exec.js` file) and updates the script to run wasm-opt with -O2 optimisations (making binaries about 2MB smaller and likely faster as well).